### PR TITLE
Include ggml/ in package .paths

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,6 +16,7 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "ggml",
         "LICENSE",
         "README.md",
     },


### PR DESCRIPTION
The local `.ggml = .{ .path = "ggml" }` dep declared in dependencies needs the `ggml/` directory to survive the package's .paths filter, otherwise consumers fail with `ggml_dep.artifact("ggml")` panicking because the directory is missing from the fetched package.